### PR TITLE
Fixes #1: Add theme fallback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,3 @@ Load helper, pass in relative directory path to `getSkinSvg()` or `getMediaSvg()
  
 ![Code Example](docs/svg_helper_usage.png)
 
-## TODO
-
-Work in skin theme inheritance if file unavailable.

--- a/src/app/code/community/Meanbee/Svg/Helper/Data.php
+++ b/src/app/code/community/Meanbee/Svg/Helper/Data.php
@@ -1,6 +1,6 @@
 <?php
 
-class Meanbee_Svg_Helper_Data extends Mage_Core_Helper_Abstract 
+class Meanbee_Svg_Helper_Data extends Mage_Core_Helper_Abstract
 {
 
     /**
@@ -10,9 +10,11 @@ class Meanbee_Svg_Helper_Data extends Mage_Core_Helper_Abstract
      */
     public function getSkinSvg($path)
     {
-        $path = Mage::getDesign()->getSkinBaseDir() . DS . $path;
+        $params = array('_type' => 'skin');
 
-        return $this->_getSvg($path);
+        $filepath = Mage::getDesign()->getFilename($path, $params);
+
+        return $this->_getSvg($filepath);
     }
 
     /**


### PR DESCRIPTION
Rather than assuming the SVG is going to be the current theme, use the getFilename function which uses the fallback implementation.  
